### PR TITLE
Productionize app on ECS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ heimdall-env/
 # Python temp
 __pycache__/
 *.pyc
+
+# Terraform
+.terraform/
+terraform.tfstate.backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:18.04
-MAINTAINER <reed@outlook.com>
 
 ENV APT_INSTALL_OPTIONS="-y --no-install-recommends"
 
@@ -26,4 +25,5 @@ RUN useradd -ms /bin/bash heimdall
 USER heimdall
 
 # Run the app
-CMD gunicorn --bind 0.0.0.0:$PORT wsgi
+ADD entrypoint.sh /src/entrypoint.sh
+CMD /src/entrypoint.sh 0.0.0.0:$PORT

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: docker-image
+
+docker-image:
+	docker build -t 371589656068.dkr.ecr.us-east-1.amazonaws.com/heimdall:latest .
+	docker push 371589656068.dkr.ecr.us-east-1.amazonaws.com/heimdall:latest
+	@echo Latest image pushed - kill the current task to finish deploy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+BIND="$1"
+# Read SLACK_TOKEN to configure app
+export SLACK_TOKEN="$(aws ssm get-parameters --names /heimdall/slack-token --with-decryption --output text | cut -f4)"
+
+gunicorn --bind "$BIND" --access-logfile - wsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+awscli
 flask
 requests
 slackclient

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -210,24 +210,6 @@ resource "aws_route53_record" "cname" {
   }
 }
 
-## Secrets
-
-resource "aws_ssm_parameter" "secret" {
-  name        = "/heimdall/slack-token"
-  description = "Slack API token"
-  type        = "SecureString"
-  value       = "changeme"
-
-  tags {
-    Config = "heimdall"
-  }
-
-  lifecycle {
-    # Real value is configured after creation
-    ignore_changes = ["value"]
-  }
-}
-
 ## ECS
 
 resource "aws_ecs_cluster" "cluster" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,314 @@
+provider "aws" {
+  version = "1.14.1"
+  region  = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.11.7"
+}
+
+locals {
+  app_port = 8080
+}
+
+data "aws_caller_identity" "current" {}
+
+## IAM
+
+resource "aws_iam_role" "execution-role" {
+  name_prefix = "heimdall-execution-"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "execution-attach" {
+  role       = "${aws_iam_role.execution-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task-role" {
+  name_prefix = "heimdall-task-"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "task-policy" {
+  name_prefix = "heimdall-task-"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/heimdall/*"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "task-attach" {
+  role       = "${aws_iam_role.task-role.name}"
+  policy_arn = "${aws_iam_policy.task-policy.arn}"
+}
+
+## Networking
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "heimdall-vpc"
+  cidr = "172.21.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = []
+  public_subnets  = ["172.21.0.0/24", "172.21.1.0/24", "172.21.2.0/24"]
+
+  enable_nat_gateway = false
+
+  tags = {
+    Terraform = "true"
+    Config    = "heimdall"
+  }
+}
+
+resource "aws_security_group" "lb" {
+  name_prefix = "heimdall-lb-"
+  description = "Controls access to the ALB"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "app" {
+  name_prefix = "heimdall-app-"
+  description = "Controls access to the app"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  ingress {
+    protocol        = "-1"
+    from_port       = 0
+    to_port         = 0
+    security_groups = ["${aws_security_group.lb.id}"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+## ALB
+
+resource "aws_alb" "main" {
+  name_prefix     = "heim-"
+  subnets         = ["${module.vpc.public_subnets}"]
+  security_groups = ["${aws_security_group.lb.id}"]
+
+  tags {
+    Config = "heimdall"
+  }
+}
+
+resource "aws_alb_target_group" "app" {
+  name_prefix          = "heim-"
+  port                 = "${local.app_port}"
+  protocol             = "HTTP"
+  vpc_id               = "${module.vpc.vpc_id}"
+  target_type          = "ip"
+  deregistration_delay = 30
+
+  health_check {
+    interval          = 6
+    healthy_threshold = 2
+  }
+}
+
+resource "aws_acm_certificate" "certificate" {
+  domain_name       = "heimdall.bnch.us"
+  validation_method = "EMAIL"
+
+  tags {
+    Config = "heimdall"
+  }
+}
+
+resource "aws_alb_listener" "front-end" {
+  load_balancer_arn = "${aws_alb.main.id}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${aws_acm_certificate.certificate.arn}"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.app.id}"
+    type             = "forward"
+  }
+}
+
+## Route 53
+
+data "aws_route53_zone" "bnch-us" {
+  name = "bnch.us"
+}
+
+resource "aws_route53_record" "cname" {
+  zone_id = "${data.aws_route53_zone.bnch-us.id}"
+  name    = "heimdall.bnch.us"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_alb.main.dns_name}"
+    zone_id                = "${aws_alb.main.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+## Secrets
+
+resource "aws_ssm_parameter" "secret" {
+  name        = "/heimdall/slack-token"
+  description = "Slack API token"
+  type        = "SecureString"
+  value       = "changeme"
+
+  tags {
+    Config = "heimdall"
+  }
+
+  lifecycle {
+    # Real value is configured after creation
+    ignore_changes = ["value"]
+  }
+}
+
+## ECS
+
+resource "aws_ecs_cluster" "cluster" {
+  name = "heimdall-cluster"
+}
+
+resource "aws_ecr_repository" "repo" {
+  name = "heimdall"
+}
+
+resource "aws_cloudwatch_log_group" "heimdall" {
+  name = "/ecs/heimdall"
+
+  tags {
+    Config = "heimdall"
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  cpu                      = 256
+  execution_role_arn       = "${aws_iam_role.execution-role.arn}"
+  family                   = "heimdall"
+  memory                   = 512
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  task_role_arn            = "${aws_iam_role.task-role.arn}"
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 256,
+    "image": "${aws_ecr_repository.repo.repository_url}:latest",
+    "memory": 512,
+    "name": "app",
+    "networkMode": "awsvpc",
+    "environment": [
+      {"name": "PORT", "value": "${local.app_port}"},
+      {"name": "ANNOUNCEMENTS_CHANNEL_ID", "value": "C0D7T48AY"}
+    ],
+    "portMappings": [
+      {
+        "containerPort": ${local.app_port}
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.heimdall.name}",
+        "awslogs-region": "us-east-1",
+        "awslogs-stream-prefix": "app"
+      }
+    }
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "service" {
+  name            = "heimdall-service"
+  cluster         = "${aws_ecs_cluster.cluster.id}"
+  task_definition = "${aws_ecs_task_definition.app.arn}"
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    assign_public_ip = true
+    security_groups  = ["${aws_security_group.app.id}"]
+    subnets          = ["${module.vpc.public_subnets}"]
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.app.id}"
+    container_name   = "app"
+    container_port   = "${local.app_port}"
+  }
+
+  depends_on = [
+    "aws_alb_listener.front-end",
+  ]
+
+  lifecycle {
+    ignore_changes = ["task_definition"]
+  }
+}

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.7",
-    "serial": 24,
+    "serial": 25,
     "lineage": "0b9cc370-c586-e703-785b-d0372bf989d4",
     "modules": [
         {
@@ -244,7 +244,7 @@
                             "network_configuration.0.subnets.377156202": "subnet-0c7d860b4db31846a",
                             "placement_constraints.#": "0",
                             "placement_strategy.#": "0",
-                            "task_definition": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:19"
+                            "task_definition": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:20"
                         },
                         "meta": {},
                         "tainted": false
@@ -264,7 +264,7 @@
                     "primary": {
                         "id": "heimdall",
                         "attributes": {
-                            "arn": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:20",
+                            "arn": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:21",
                             "container_definitions": "[{\"cpu\":256,\"environment\":[{\"name\":\"PORT\",\"value\":\"8080\"},{\"name\":\"ANNOUNCEMENTS_CHANNEL_ID\",\"value\":\"C0D7T48AY\"}],\"essential\":true,\"image\":\"371589656068.dkr.ecr.us-east-1.amazonaws.com/heimdall:latest\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"/ecs/heimdall\",\"awslogs-region\":\"us-east-1\",\"awslogs-stream-prefix\":\"app\"}},\"memory\":512,\"mountPoints\":[],\"name\":\"app\",\"portMappings\":[{\"containerPort\":8080,\"hostPort\":8080,\"protocol\":\"tcp\"}],\"volumesFrom\":[]}]",
                             "cpu": "256",
                             "execution_role_arn": "arn:aws:iam::371589656068:role/heimdall-execution-20180701200727990300000001",
@@ -275,7 +275,7 @@
                             "placement_constraints.#": "0",
                             "requires_compatibilities.#": "1",
                             "requires_compatibilities.3072437307": "FARGATE",
-                            "revision": "20",
+                            "revision": "21",
                             "task_role_arn": "arn:aws:iam::371589656068:role/heimdall-task-20180702050935824400000002",
                             "volume.#": "0"
                         },
@@ -526,39 +526,16 @@
                     "deposed": [],
                     "provider": "provider.aws"
                 },
-                "aws_ssm_parameter.secret": {
-                    "type": "aws_ssm_parameter",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "/heimdall/slack-token",
-                        "attributes": {
-                            "allowed_pattern": "",
-                            "arn": "arn:aws:ssm:us-east-1:371589656068:parameter/heimdall/slack-token",
-                            "description": "Slack API token",
-                            "id": "/heimdall/slack-token",
-                            "key_id": "alias/aws/ssm",
-                            "name": "/heimdall/slack-token",
-                            "tags.%": "1",
-                            "tags.Config": "heimdall",
-                            "type": "SecureString",
-                            "value": "xoxp-2180192983-2180192985-390477711296-7481e8bf13260adaa731b9b48f54af0e"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
                 "data.aws_caller_identity.current": {
                     "type": "aws_caller_identity",
                     "depends_on": [],
                     "primary": {
-                        "id": "2018-07-02 06:15:10.027126 +0000 UTC",
+                        "id": "2018-07-02 07:12:03.5086 +0000 UTC",
                         "attributes": {
                             "account_id": "371589656068",
-                            "arn": "arn:aws:sts::371589656068:assumed-role/opsRole/1530512104642639000",
-                            "id": "2018-07-02 06:15:10.027126 +0000 UTC",
-                            "user_id": "AROAJFYSRCGPFO3YPLUKS:1530512104642639000"
+                            "arn": "arn:aws:sts::371589656068:assumed-role/opsRole/1530515518689212000",
+                            "id": "2018-07-02 07:12:03.5086 +0000 UTC",
+                            "user_id": "AROAJFYSRCGPFO3YPLUKS:1530515518689212000"
                         },
                         "meta": {},
                         "tainted": false

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,0 +1,1100 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.7",
+    "serial": 24,
+    "lineage": "0b9cc370-c586-e703-785b-d0372bf989d4",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "aws_acm_certificate.certificate": {
+                    "type": "aws_acm_certificate",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "arn:aws:acm:us-east-1:371589656068:certificate/c3c3822c-63b7-40ec-ab47-ab8fb4b4a05d",
+                        "attributes": {
+                            "arn": "arn:aws:acm:us-east-1:371589656068:certificate/c3c3822c-63b7-40ec-ab47-ab8fb4b4a05d",
+                            "domain_name": "heimdall.bnch.us",
+                            "domain_validation_options.#": "0",
+                            "id": "arn:aws:acm:us-east-1:371589656068:certificate/c3c3822c-63b7-40ec-ab47-ab8fb4b4a05d",
+                            "subject_alternative_names.#": "0",
+                            "tags.%": "1",
+                            "tags.Config": "heimdall",
+                            "validation_emails.#": "7",
+                            "validation_emails.0": "webmaster@heimdall.bnch.us",
+                            "validation_emails.1": "admin@heimdall.bnch.us",
+                            "validation_emails.2": "822a0064163402c40390161bba2a41d7-7876014@contact.gandi.net",
+                            "validation_emails.3": "hostmaster@heimdall.bnch.us",
+                            "validation_emails.4": "postmaster@heimdall.bnch.us",
+                            "validation_emails.5": "administrator@heimdall.bnch.us",
+                            "validation_emails.6": "domains@benchling.com",
+                            "validation_method": "EMAIL"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_alb.main": {
+                    "type": "aws_alb",
+                    "depends_on": [
+                        "aws_security_group.lb",
+                        "module.vpc"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:loadbalancer/app/heim-20180701194658639400000001/d4229efe2c5393bc",
+                        "attributes": {
+                            "access_logs.#": "0",
+                            "arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:loadbalancer/app/heim-20180701194658639400000001/d4229efe2c5393bc",
+                            "arn_suffix": "app/heim-20180701194658639400000001/d4229efe2c5393bc",
+                            "dns_name": "heim-20180701194658639400000001-235506014.us-east-1.elb.amazonaws.com",
+                            "enable_deletion_protection": "false",
+                            "enable_http2": "true",
+                            "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:loadbalancer/app/heim-20180701194658639400000001/d4229efe2c5393bc",
+                            "idle_timeout": "60",
+                            "internal": "false",
+                            "ip_address_type": "ipv4",
+                            "load_balancer_type": "application",
+                            "name": "heim-20180701194658639400000001",
+                            "name_prefix": "heim-",
+                            "security_groups.#": "1",
+                            "security_groups.2029868055": "sg-069ce457d2b91c0c7",
+                            "subnet_mapping.#": "0",
+                            "subnets.#": "3",
+                            "subnets.2603193878": "subnet-0f1a5553f7b2d26ee",
+                            "subnets.2828061844": "subnet-0be956a18e2529815",
+                            "subnets.377156202": "subnet-0c7d860b4db31846a",
+                            "tags.%": "1",
+                            "tags.Config": "heimdall",
+                            "vpc_id": "vpc-07a03d56b931f4004",
+                            "zone_id": "Z35SXDOTRQ7X7K"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000,
+                                "update": 600000000000
+                            }
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_alb_listener.front-end": {
+                    "type": "aws_alb_listener",
+                    "depends_on": [
+                        "aws_acm_certificate.certificate",
+                        "aws_alb.main",
+                        "aws_alb_target_group.app"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:listener/app/heim-20180701194658639400000001/d4229efe2c5393bc/c7fd99608f252846",
+                        "attributes": {
+                            "arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:listener/app/heim-20180701194658639400000001/d4229efe2c5393bc/c7fd99608f252846",
+                            "certificate_arn": "arn:aws:acm:us-east-1:371589656068:certificate/c3c3822c-63b7-40ec-ab47-ab8fb4b4a05d",
+                            "default_action.#": "1",
+                            "default_action.0.target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                            "default_action.0.type": "forward",
+                            "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:listener/app/heim-20180701194658639400000001/d4229efe2c5393bc/c7fd99608f252846",
+                            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:loadbalancer/app/heim-20180701194658639400000001/d4229efe2c5393bc",
+                            "port": "443",
+                            "protocol": "HTTPS",
+                            "ssl_policy": "ELBSecurityPolicy-2016-08"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_alb_target_group.app": {
+                    "type": "aws_alb_target_group",
+                    "depends_on": [
+                        "local.app_port",
+                        "module.vpc"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                        "attributes": {
+                            "arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                            "arn_suffix": "targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                            "deregistration_delay": "30",
+                            "health_check.#": "1",
+                            "health_check.0.healthy_threshold": "2",
+                            "health_check.0.interval": "6",
+                            "health_check.0.matcher": "200",
+                            "health_check.0.path": "/",
+                            "health_check.0.port": "traffic-port",
+                            "health_check.0.protocol": "HTTP",
+                            "health_check.0.timeout": "5",
+                            "health_check.0.unhealthy_threshold": "3",
+                            "id": "arn:aws:elasticloadbalancing:us-east-1:371589656068:targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                            "name": "heim-20180702041853561700000001",
+                            "name_prefix": "heim-",
+                            "port": "8080",
+                            "protocol": "HTTP",
+                            "stickiness.#": "1",
+                            "stickiness.0.cookie_duration": "86400",
+                            "stickiness.0.enabled": "false",
+                            "stickiness.0.type": "lb_cookie",
+                            "tags.%": "0",
+                            "target_type": "ip",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_cloudwatch_log_group.heimdall": {
+                    "type": "aws_cloudwatch_log_group",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "/ecs/heimdall",
+                        "attributes": {
+                            "arn": "arn:aws:logs:us-east-1:371589656068:log-group:/ecs/heimdall:*",
+                            "id": "/ecs/heimdall",
+                            "kms_key_id": "",
+                            "name": "/ecs/heimdall",
+                            "retention_in_days": "0",
+                            "tags.%": "1",
+                            "tags.Config": "heimdall"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_ecr_repository.repo": {
+                    "type": "aws_ecr_repository",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "heimdall",
+                        "attributes": {
+                            "arn": "arn:aws:ecr:us-east-1:371589656068:repository/heimdall",
+                            "id": "heimdall",
+                            "name": "heimdall",
+                            "registry_id": "371589656068",
+                            "repository_url": "371589656068.dkr.ecr.us-east-1.amazonaws.com/heimdall"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_ecs_cluster.cluster": {
+                    "type": "aws_ecs_cluster",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "arn:aws:ecs:us-east-1:371589656068:cluster/heimdall-cluster",
+                        "attributes": {
+                            "arn": "arn:aws:ecs:us-east-1:371589656068:cluster/heimdall-cluster",
+                            "id": "arn:aws:ecs:us-east-1:371589656068:cluster/heimdall-cluster",
+                            "name": "heimdall-cluster"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_ecs_service.service": {
+                    "type": "aws_ecs_service",
+                    "depends_on": [
+                        "aws_alb_listener.front-end",
+                        "aws_alb_target_group.app",
+                        "aws_ecs_cluster.cluster",
+                        "aws_ecs_task_definition.app",
+                        "aws_security_group.app",
+                        "local.app_port",
+                        "module.vpc"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:ecs:us-east-1:371589656068:service/heimdall-service",
+                        "attributes": {
+                            "cluster": "arn:aws:ecs:us-east-1:371589656068:cluster/heimdall-cluster",
+                            "deployment_maximum_percent": "200",
+                            "deployment_minimum_healthy_percent": "100",
+                            "desired_count": "1",
+                            "health_check_grace_period_seconds": "0",
+                            "iam_role": "aws-service-role",
+                            "id": "arn:aws:ecs:us-east-1:371589656068:service/heimdall-service",
+                            "launch_type": "FARGATE",
+                            "load_balancer.#": "1",
+                            "load_balancer.3916419246.container_name": "app",
+                            "load_balancer.3916419246.container_port": "8080",
+                            "load_balancer.3916419246.elb_name": "",
+                            "load_balancer.3916419246.target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:371589656068:targetgroup/heim-20180702041853561700000001/ae1ed967ea026ed3",
+                            "name": "heimdall-service",
+                            "network_configuration.#": "1",
+                            "network_configuration.0.assign_public_ip": "true",
+                            "network_configuration.0.security_groups.#": "1",
+                            "network_configuration.0.security_groups.1502768182": "sg-0f9725250a16f1d46",
+                            "network_configuration.0.subnets.#": "3",
+                            "network_configuration.0.subnets.2603193878": "subnet-0f1a5553f7b2d26ee",
+                            "network_configuration.0.subnets.2828061844": "subnet-0be956a18e2529815",
+                            "network_configuration.0.subnets.377156202": "subnet-0c7d860b4db31846a",
+                            "placement_constraints.#": "0",
+                            "placement_strategy.#": "0",
+                            "task_definition": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:19"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_ecs_task_definition.app": {
+                    "type": "aws_ecs_task_definition",
+                    "depends_on": [
+                        "aws_cloudwatch_log_group.heimdall",
+                        "aws_ecr_repository.repo",
+                        "aws_iam_role.execution-role",
+                        "aws_iam_role.task-role",
+                        "local.app_port"
+                    ],
+                    "primary": {
+                        "id": "heimdall",
+                        "attributes": {
+                            "arn": "arn:aws:ecs:us-east-1:371589656068:task-definition/heimdall:20",
+                            "container_definitions": "[{\"cpu\":256,\"environment\":[{\"name\":\"PORT\",\"value\":\"8080\"},{\"name\":\"ANNOUNCEMENTS_CHANNEL_ID\",\"value\":\"C0D7T48AY\"}],\"essential\":true,\"image\":\"371589656068.dkr.ecr.us-east-1.amazonaws.com/heimdall:latest\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"/ecs/heimdall\",\"awslogs-region\":\"us-east-1\",\"awslogs-stream-prefix\":\"app\"}},\"memory\":512,\"mountPoints\":[],\"name\":\"app\",\"portMappings\":[{\"containerPort\":8080,\"hostPort\":8080,\"protocol\":\"tcp\"}],\"volumesFrom\":[]}]",
+                            "cpu": "256",
+                            "execution_role_arn": "arn:aws:iam::371589656068:role/heimdall-execution-20180701200727990300000001",
+                            "family": "heimdall",
+                            "id": "heimdall",
+                            "memory": "512",
+                            "network_mode": "awsvpc",
+                            "placement_constraints.#": "0",
+                            "requires_compatibilities.#": "1",
+                            "requires_compatibilities.3072437307": "FARGATE",
+                            "revision": "20",
+                            "task_role_arn": "arn:aws:iam::371589656068:role/heimdall-task-20180702050935824400000002",
+                            "volume.#": "0"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_iam_policy.task-policy": {
+                    "type": "aws_iam_policy",
+                    "depends_on": [
+                        "data.aws_caller_identity.current"
+                    ],
+                    "primary": {
+                        "id": "arn:aws:iam::371589656068:policy/heimdall-task-20180702050935824200000001",
+                        "attributes": {
+                            "arn": "arn:aws:iam::371589656068:policy/heimdall-task-20180702050935824200000001",
+                            "id": "arn:aws:iam::371589656068:policy/heimdall-task-20180702050935824200000001",
+                            "name": "heimdall-task-20180702050935824200000001",
+                            "name_prefix": "heimdall-task-",
+                            "path": "/",
+                            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ssm:GetParameters\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": [\n        \"arn:aws:ssm:us-east-1:371589656068:parameter/heimdall/*\"\n      ]\n    }\n  ]\n}\n"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_iam_role.execution-role": {
+                    "type": "aws_iam_role",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "heimdall-execution-20180701200727990300000001",
+                        "attributes": {
+                            "arn": "arn:aws:iam::371589656068:role/heimdall-execution-20180701200727990300000001",
+                            "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                            "create_date": "2018-07-01T20:07:28Z",
+                            "force_detach_policies": "false",
+                            "id": "heimdall-execution-20180701200727990300000001",
+                            "max_session_duration": "3600",
+                            "name": "heimdall-execution-20180701200727990300000001",
+                            "name_prefix": "heimdall-execution-",
+                            "path": "/",
+                            "unique_id": "AROAJVAMO23XOQX7FBBZK"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_iam_role.task-role": {
+                    "type": "aws_iam_role",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "heimdall-task-20180702050935824400000002",
+                        "attributes": {
+                            "arn": "arn:aws:iam::371589656068:role/heimdall-task-20180702050935824400000002",
+                            "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                            "create_date": "2018-07-02T05:09:36Z",
+                            "force_detach_policies": "false",
+                            "id": "heimdall-task-20180702050935824400000002",
+                            "max_session_duration": "3600",
+                            "name": "heimdall-task-20180702050935824400000002",
+                            "name_prefix": "heimdall-task-",
+                            "path": "/",
+                            "unique_id": "AROAJ64A7KFAQUAZMLMRA"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_iam_role_policy_attachment.execution-attach": {
+                    "type": "aws_iam_role_policy_attachment",
+                    "depends_on": [
+                        "aws_iam_role.execution-role"
+                    ],
+                    "primary": {
+                        "id": "heimdall-execution-20180701200727990300000001-20180701200729418200000002",
+                        "attributes": {
+                            "id": "heimdall-execution-20180701200727990300000001-20180701200729418200000002",
+                            "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+                            "role": "heimdall-execution-20180701200727990300000001"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_iam_role_policy_attachment.task-attach": {
+                    "type": "aws_iam_role_policy_attachment",
+                    "depends_on": [
+                        "aws_iam_policy.task-policy",
+                        "aws_iam_role.task-role"
+                    ],
+                    "primary": {
+                        "id": "heimdall-task-20180702050935824400000002-20180702050937231200000003",
+                        "attributes": {
+                            "id": "heimdall-task-20180702050935824400000002-20180702050937231200000003",
+                            "policy_arn": "arn:aws:iam::371589656068:policy/heimdall-task-20180702050935824200000001",
+                            "role": "heimdall-task-20180702050935824400000002"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route53_record.cname": {
+                    "type": "aws_route53_record",
+                    "depends_on": [
+                        "aws_alb.main",
+                        "data.aws_route53_zone.bnch-us"
+                    ],
+                    "primary": {
+                        "id": "Z1EVGDN2PX4Q5H_heimdall.bnch.us_A",
+                        "attributes": {
+                            "alias.#": "1",
+                            "alias.3287900174.evaluate_target_health": "true",
+                            "alias.3287900174.name": "heim-20180701194658639400000001-235506014.us-east-1.elb.amazonaws.com",
+                            "alias.3287900174.zone_id": "Z35SXDOTRQ7X7K",
+                            "allow_overwrite": "true",
+                            "fqdn": "heimdall.bnch.us",
+                            "health_check_id": "",
+                            "id": "Z1EVGDN2PX4Q5H_heimdall.bnch.us_A",
+                            "name": "heimdall.bnch.us",
+                            "records.#": "0",
+                            "set_identifier": "",
+                            "ttl": "0",
+                            "type": "A",
+                            "zone_id": "Z1EVGDN2PX4Q5H"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_security_group.app": {
+                    "type": "aws_security_group",
+                    "depends_on": [
+                        "aws_security_group.lb",
+                        "module.vpc"
+                    ],
+                    "primary": {
+                        "id": "sg-0f9725250a16f1d46",
+                        "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:371589656068:security-group/sg-0f9725250a16f1d46",
+                            "description": "Controls access to the app",
+                            "egress.#": "1",
+                            "egress.482069346.cidr_blocks.#": "1",
+                            "egress.482069346.cidr_blocks.0": "0.0.0.0/0",
+                            "egress.482069346.description": "",
+                            "egress.482069346.from_port": "0",
+                            "egress.482069346.ipv6_cidr_blocks.#": "0",
+                            "egress.482069346.prefix_list_ids.#": "0",
+                            "egress.482069346.protocol": "-1",
+                            "egress.482069346.security_groups.#": "0",
+                            "egress.482069346.self": "false",
+                            "egress.482069346.to_port": "0",
+                            "id": "sg-0f9725250a16f1d46",
+                            "ingress.#": "1",
+                            "ingress.558737647.cidr_blocks.#": "0",
+                            "ingress.558737647.description": "",
+                            "ingress.558737647.from_port": "0",
+                            "ingress.558737647.ipv6_cidr_blocks.#": "0",
+                            "ingress.558737647.protocol": "-1",
+                            "ingress.558737647.security_groups.#": "1",
+                            "ingress.558737647.security_groups.2029868055": "sg-069ce457d2b91c0c7",
+                            "ingress.558737647.self": "false",
+                            "ingress.558737647.to_port": "0",
+                            "name": "heimdall-app-20180701193539879100000004",
+                            "name_prefix": "heimdall-app-",
+                            "owner_id": "371589656068",
+                            "revoke_rules_on_delete": "false",
+                            "tags.%": "0",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000
+                            },
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_security_group.lb": {
+                    "type": "aws_security_group",
+                    "depends_on": [
+                        "module.vpc"
+                    ],
+                    "primary": {
+                        "id": "sg-069ce457d2b91c0c7",
+                        "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:371589656068:security-group/sg-069ce457d2b91c0c7",
+                            "description": "Controls access to the ALB",
+                            "egress.#": "1",
+                            "egress.482069346.cidr_blocks.#": "1",
+                            "egress.482069346.cidr_blocks.0": "0.0.0.0/0",
+                            "egress.482069346.description": "",
+                            "egress.482069346.from_port": "0",
+                            "egress.482069346.ipv6_cidr_blocks.#": "0",
+                            "egress.482069346.prefix_list_ids.#": "0",
+                            "egress.482069346.protocol": "-1",
+                            "egress.482069346.security_groups.#": "0",
+                            "egress.482069346.self": "false",
+                            "egress.482069346.to_port": "0",
+                            "id": "sg-069ce457d2b91c0c7",
+                            "ingress.#": "1",
+                            "ingress.2617001939.cidr_blocks.#": "1",
+                            "ingress.2617001939.cidr_blocks.0": "0.0.0.0/0",
+                            "ingress.2617001939.description": "",
+                            "ingress.2617001939.from_port": "443",
+                            "ingress.2617001939.ipv6_cidr_blocks.#": "0",
+                            "ingress.2617001939.protocol": "tcp",
+                            "ingress.2617001939.security_groups.#": "0",
+                            "ingress.2617001939.self": "false",
+                            "ingress.2617001939.to_port": "443",
+                            "name": "heimdall-lb-20180701193532101300000002",
+                            "name_prefix": "heimdall-lb-",
+                            "owner_id": "371589656068",
+                            "revoke_rules_on_delete": "false",
+                            "tags.%": "0",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 600000000000,
+                                "delete": 600000000000
+                            },
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_ssm_parameter.secret": {
+                    "type": "aws_ssm_parameter",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "/heimdall/slack-token",
+                        "attributes": {
+                            "allowed_pattern": "",
+                            "arn": "arn:aws:ssm:us-east-1:371589656068:parameter/heimdall/slack-token",
+                            "description": "Slack API token",
+                            "id": "/heimdall/slack-token",
+                            "key_id": "alias/aws/ssm",
+                            "name": "/heimdall/slack-token",
+                            "tags.%": "1",
+                            "tags.Config": "heimdall",
+                            "type": "SecureString",
+                            "value": "xoxp-2180192983-2180192985-390477711296-7481e8bf13260adaa731b9b48f54af0e"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "data.aws_caller_identity.current": {
+                    "type": "aws_caller_identity",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "2018-07-02 06:15:10.027126 +0000 UTC",
+                        "attributes": {
+                            "account_id": "371589656068",
+                            "arn": "arn:aws:sts::371589656068:assumed-role/opsRole/1530512104642639000",
+                            "id": "2018-07-02 06:15:10.027126 +0000 UTC",
+                            "user_id": "AROAJFYSRCGPFO3YPLUKS:1530512104642639000"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "data.aws_route53_zone.bnch-us": {
+                    "type": "aws_route53_zone",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "Z1EVGDN2PX4Q5H",
+                        "attributes": {
+                            "caller_reference": "RISWorkflow-177da441dda6b5c1491491be16fef283",
+                            "comment": "HostedZone created by Route53 Registrar",
+                            "id": "Z1EVGDN2PX4Q5H",
+                            "name": "bnch.us.",
+                            "private_zone": "false",
+                            "resource_record_set_count": "11",
+                            "zone_id": "Z1EVGDN2PX4Q5H"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                }
+            },
+            "depends_on": []
+        },
+        {
+            "path": [
+                "root",
+                "vpc"
+            ],
+            "outputs": {
+                "database_subnet_group": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "database_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "database_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "default_network_acl_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "acl-07493f37f82490cca"
+                },
+                "default_route_table_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "rtb-09817fd7ec963c3ab"
+                },
+                "default_security_group_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "sg-0d0801949204c903b"
+                },
+                "default_vpc_cidr_block": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_default_network_acl_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_default_route_table_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_default_security_group_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_enable_dns_hostnames": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_enable_dns_support": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_instance_tenancy": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "default_vpc_main_route_table_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "elasticache_subnet_group": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "elasticache_subnet_group_name": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "elasticache_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "elasticache_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "igw_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "igw-089154dcef78cb7e7"
+                },
+                "intra_route_table_ids": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "intra_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "intra_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "nat_ids": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "nat_public_ips": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "natgw_ids": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "private_route_table_ids": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "private_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "private_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "public_route_table_ids": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": [
+                        "rtb-0d38c907d342732bc"
+                    ]
+                },
+                "public_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": [
+                        "subnet-0be956a18e2529815",
+                        "subnet-0f1a5553f7b2d26ee",
+                        "subnet-0c7d860b4db31846a"
+                    ]
+                },
+                "public_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": [
+                        "172.21.0.0/24",
+                        "172.21.1.0/24",
+                        "172.21.2.0/24"
+                    ]
+                },
+                "redshift_subnet_group": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "redshift_subnets": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "redshift_subnets_cidr_blocks": {
+                    "sensitive": false,
+                    "type": "list",
+                    "value": []
+                },
+                "vgw_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "vpc_cidr_block": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "172.21.0.0/16"
+                },
+                "vpc_enable_dns_hostnames": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "false"
+                },
+                "vpc_enable_dns_support": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "true"
+                },
+                "vpc_endpoint_dynamodb_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "vpc_endpoint_dynamodb_pl_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "vpc_endpoint_s3_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "vpc_endpoint_s3_pl_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": ""
+                },
+                "vpc_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "vpc-07a03d56b931f4004"
+                },
+                "vpc_instance_tenancy": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "default"
+                },
+                "vpc_main_route_table_id": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "rtb-09817fd7ec963c3ab"
+                }
+            },
+            "resources": {
+                "aws_internet_gateway.this": {
+                    "type": "aws_internet_gateway",
+                    "depends_on": [
+                        "aws_vpc.this"
+                    ],
+                    "primary": {
+                        "id": "igw-089154dcef78cb7e7",
+                        "attributes": {
+                            "id": "igw-089154dcef78cb7e7",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc",
+                            "tags.Terraform": "true",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route.public_internet_gateway": {
+                    "type": "aws_route",
+                    "depends_on": [
+                        "aws_internet_gateway.this",
+                        "aws_route_table.public"
+                    ],
+                    "primary": {
+                        "id": "r-rtb-0d38c907d342732bc1080289494",
+                        "attributes": {
+                            "destination_cidr_block": "0.0.0.0/0",
+                            "destination_prefix_list_id": "",
+                            "egress_only_gateway_id": "",
+                            "gateway_id": "igw-089154dcef78cb7e7",
+                            "id": "r-rtb-0d38c907d342732bc1080289494",
+                            "instance_id": "",
+                            "instance_owner_id": "",
+                            "nat_gateway_id": "",
+                            "network_interface_id": "",
+                            "origin": "CreateRoute",
+                            "route_table_id": "rtb-0d38c907d342732bc",
+                            "state": "active",
+                            "vpc_peering_connection_id": ""
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 300000000000,
+                                "delete": 300000000000
+                            }
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table.public": {
+                    "type": "aws_route_table",
+                    "depends_on": [
+                        "aws_vpc.this"
+                    ],
+                    "primary": {
+                        "id": "rtb-0d38c907d342732bc",
+                        "attributes": {
+                            "id": "rtb-0d38c907d342732bc",
+                            "propagating_vgws.#": "0",
+                            "route.#": "1",
+                            "route.173240042.cidr_block": "0.0.0.0/0",
+                            "route.173240042.egress_only_gateway_id": "",
+                            "route.173240042.gateway_id": "igw-089154dcef78cb7e7",
+                            "route.173240042.instance_id": "",
+                            "route.173240042.ipv6_cidr_block": "",
+                            "route.173240042.nat_gateway_id": "",
+                            "route.173240042.network_interface_id": "",
+                            "route.173240042.vpc_peering_connection_id": "",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc-public",
+                            "tags.Terraform": "true",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table_association.public.0": {
+                    "type": "aws_route_table_association",
+                    "depends_on": [
+                        "aws_route_table.public",
+                        "aws_subnet.public.*"
+                    ],
+                    "primary": {
+                        "id": "rtbassoc-0dda15094d6d15894",
+                        "attributes": {
+                            "id": "rtbassoc-0dda15094d6d15894",
+                            "route_table_id": "rtb-0d38c907d342732bc",
+                            "subnet_id": "subnet-0be956a18e2529815"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table_association.public.1": {
+                    "type": "aws_route_table_association",
+                    "depends_on": [
+                        "aws_route_table.public",
+                        "aws_subnet.public.*"
+                    ],
+                    "primary": {
+                        "id": "rtbassoc-0390eac6905f08c11",
+                        "attributes": {
+                            "id": "rtbassoc-0390eac6905f08c11",
+                            "route_table_id": "rtb-0d38c907d342732bc",
+                            "subnet_id": "subnet-0f1a5553f7b2d26ee"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route_table_association.public.2": {
+                    "type": "aws_route_table_association",
+                    "depends_on": [
+                        "aws_route_table.public",
+                        "aws_subnet.public.*"
+                    ],
+                    "primary": {
+                        "id": "rtbassoc-06d49eb97237576b3",
+                        "attributes": {
+                            "id": "rtbassoc-06d49eb97237576b3",
+                            "route_table_id": "rtb-0d38c907d342732bc",
+                            "subnet_id": "subnet-0c7d860b4db31846a"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_subnet.public.0": {
+                    "type": "aws_subnet",
+                    "depends_on": [
+                        "aws_vpc.this"
+                    ],
+                    "primary": {
+                        "id": "subnet-0be956a18e2529815",
+                        "attributes": {
+                            "assign_ipv6_address_on_creation": "false",
+                            "availability_zone": "us-east-1a",
+                            "cidr_block": "172.21.0.0/24",
+                            "id": "subnet-0be956a18e2529815",
+                            "map_public_ip_on_launch": "true",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc-public-us-east-1a",
+                            "tags.Terraform": "true",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_subnet.public.1": {
+                    "type": "aws_subnet",
+                    "depends_on": [
+                        "aws_vpc.this"
+                    ],
+                    "primary": {
+                        "id": "subnet-0f1a5553f7b2d26ee",
+                        "attributes": {
+                            "assign_ipv6_address_on_creation": "false",
+                            "availability_zone": "us-east-1b",
+                            "cidr_block": "172.21.1.0/24",
+                            "id": "subnet-0f1a5553f7b2d26ee",
+                            "map_public_ip_on_launch": "true",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc-public-us-east-1b",
+                            "tags.Terraform": "true",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_subnet.public.2": {
+                    "type": "aws_subnet",
+                    "depends_on": [
+                        "aws_vpc.this"
+                    ],
+                    "primary": {
+                        "id": "subnet-0c7d860b4db31846a",
+                        "attributes": {
+                            "assign_ipv6_address_on_creation": "false",
+                            "availability_zone": "us-east-1c",
+                            "cidr_block": "172.21.2.0/24",
+                            "id": "subnet-0c7d860b4db31846a",
+                            "map_public_ip_on_launch": "true",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc-public-us-east-1c",
+                            "tags.Terraform": "true",
+                            "vpc_id": "vpc-07a03d56b931f4004"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_vpc.this": {
+                    "type": "aws_vpc",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "vpc-07a03d56b931f4004",
+                        "attributes": {
+                            "assign_generated_ipv6_cidr_block": "false",
+                            "cidr_block": "172.21.0.0/16",
+                            "default_network_acl_id": "acl-07493f37f82490cca",
+                            "default_route_table_id": "rtb-09817fd7ec963c3ab",
+                            "default_security_group_id": "sg-0d0801949204c903b",
+                            "dhcp_options_id": "dopt-c17869a3",
+                            "enable_classiclink": "false",
+                            "enable_classiclink_dns_support": "false",
+                            "enable_dns_hostnames": "false",
+                            "enable_dns_support": "true",
+                            "id": "vpc-07a03d56b931f4004",
+                            "instance_tenancy": "default",
+                            "main_route_table_id": "rtb-09817fd7ec963c3ab",
+                            "tags.%": "3",
+                            "tags.Config": "heimdall",
+                            "tags.Name": "heimdall-vpc",
+                            "tags.Terraform": "true"
+                        },
+                        "meta": {
+                            "schema_version": "1"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}


### PR DESCRIPTION
- Add terraform configuration and apply
- Wrap entrypoint in entrypoint.sh - reads slack token from SSM
  parameter store (where we can store the secret securely)
- Add _slack_api_call call to error on bad responses - helps for
  debugging
- Minor cleanup of Dockerfile (MAINTAINER is deprecated)

The current deploy process is pretty ad hoc:
```
$ make docker-image
Find the Task in the ECS console and kill it:
https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/heimdall-cluster/tasks
```