### PR TITLE
Fix configuration to run in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Files
 config.py
+slack_token.txt
 
 # Dependencies
 heimdall-env/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Three endpoints:
 - /: Hello world (just for testing)
 - /events: Listens to events from Slack, supports two (created channel & unarchived channel)
 - /things: An action for messages that creates a URL to add a task to Things based on the message
+
+## Development
+- Create `slack_token.txt` containing the OAuth Access Token
+- Run the app with `docker-compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.6"
+services:
+  app:
+    build: .
+    environment:
+      - ANNOUNCEMENTS_CHANNEL_ID=C0D7T48AY
+      - PORT=8080
+    ports:
+      - "8080:8080"
+    secrets:
+      - slack_token
+secrets:
+  slack_token:
+    file: ./slack_token.txt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 BIND="$1"
-# Read SLACK_TOKEN to configure app
-export SLACK_TOKEN="$(aws ssm get-parameters --names /heimdall/slack-token --with-decryption --output text | cut -f4)"
+if [[ -z "${SLACK_TOKEN+x}" ]]; then
+  # Read SLACK_TOKEN to configure app if not set:
+  # /run/secrets for dev mode (docker-compose)
+  # aws ssm for prod mode (AWS ECS)
+  export SLACK_TOKEN="$(
+    cat /run/secrets/slack_token \
+    || aws ssm get-parameters --names /heimdall/slack-token --with-decryption --output text | cut -f4
+  )"
+fi
 
 gunicorn --bind "$BIND" --access-logfile - wsgi

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -107,7 +107,3 @@ def things():
         _slack_api_call('chat.postMessage', channel=u'@{}'.format(data['user']['name']), text=text)
 
     return ''
-
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0')


### PR DESCRIPTION
- If SLACK_TOKEN is set, do not override it - while this isn't actually
  used in practice, seems nice to keep container image "portable"
- Use docker-compose secrets to manage the slack token in development -
  reads slack_token.txt to configure - it creates a file called
  /run/secrets/slack_token on the container
- Because docker-compose is the recommended way now, remove the
  app.run() call in app.py